### PR TITLE
Update template to support generation 2 of cloud functions

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,4 +11,4 @@ steps:
     args:
       - "-c"
       - |
-        gcloud functions deploy ts-template --runtime nodejs16 --trigger-http --allow-unauthenticated --region australia-southeast1 --entry-point helloWorld
+        gcloud functions deploy ts-template --gen2 --runtime=nodejs16 --trigger-http --allow-unauthenticated --region australia-southeast1 --entry-point=helloWorld


### PR DESCRIPTION
update cloudbuild yaml to support gen 2

[Google cloud announced](https://cloud.google.com/blog/products/serverless/cloud-functions-2nd-generation-now-generally-available) that Gen 2 of cloud functions went GA 2 days ago.